### PR TITLE
Adapt to changes in Emacs 26

### DIFF
--- a/spinner.el
+++ b/spinner.el
@@ -183,7 +183,7 @@ own spinner animations."
   (frames (spinner--type-to-frames type))
   (counter 0)
   (fps (or frames-per-second spinner-frames-per-second))
-  (timer (timer-create) :read-only)
+  (timer (timer-create) :read-only nil)
   (active-p nil)
   (buffer (when buffer-local
             (if (bufferp buffer-local)


### PR DESCRIPTION
The slots in defstruct are now checked for the correct amount of
options.

See http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=eb610f270ea919107b10bb8ece200a87abac6e0e

Fixes #8
