### PR TITLE
Fix for latest emacs-snapshot changes.

### DIFF
--- a/spinner.el
+++ b/spinner.el
@@ -183,7 +183,7 @@ own spinner animations."
   (frames (spinner--type-to-frames type))
   (counter 0)
   (fps (or frames-per-second spinner-frames-per-second))
-  (timer (timer-create) :read-only)
+  (timer (timer-create) :read-only t)
   (active-p nil)
   (buffer (when buffer-local
             (if (bufferp buffer-local)


### PR DESCRIPTION
On the latest emacs-snapshot I get this error:

```
Debugger entered--Lisp error: (error "Invalid options for slot timer in spinner")
  signal(error ("Invalid options for slot timer in spinner"))
  error("Invalid options for slot %s in %s" timer spinner)
  #[385 ":\203\n @\202 \243\303\211\304!\305P\306\307\310\"!\303\306\ ... 8< ...
  (defstruct (spinner (:copier nil) (:conc-name spinner--) (:constructor ma ... 8< ...
  eval-buffer(#<buffer  *load*> nil "/home/matt/.emacs.d/elpa/spinner-1.7.1/spinner.el" nil t)  ; Reading at buffer position 7645
  load-with-code-conversion("/home/matt/.emacs.d/elpa/spinner-1.7.1/spinner.el" "/home/matt/.emacs.d/elpa/spinner-1.7.1/spinner.el" nil t)
  require(spinner)
  eval((require (quote spinner)) nil)
  elisp--eval-last-sexp(nil)
  eval-last-sexp(nil)
  funcall-interactively(eval-last-sexp nil)
  #<subr call-interactively>(eval-last-sexp nil nil)
  ad-Advice-call-interactively(#<subr call-interactively> eval-last-sexp nil nil)
  apply(ad-Advice-call-interactively #<subr call-interactively> (eval-last-sexp nil nil))
  call-interactively(eval-last-sexp nil nil)
  command-execute(eval-last-sexp)
```

From the docs for `defstruct` about the `:read-only` argument:

> Currently, only one keyword is supported, `:read-only'.  If this has a non-nil value, that slot cannot be set via`setf'.

This change fixes this issue by adding `t` as the value for `:read-only` for the timer slot.

Thanks for the library! I hope this is useful :)
